### PR TITLE
Allow `host` config for `oper` block with fingerprint

### DIFF
--- a/conf/opers.sh
+++ b/conf/opers.sh
@@ -132,6 +132,12 @@ cat <<EOF
       # the private key is well-protected! Requires m_sslinfo.
       autologin="&operAutologin;"
 
+      # host: What hostnames and IPs are allowed to use this operator account.
+      # Multiple options can be separated by spaces and CIDRs are allowed.
+      # You can use just * or *@* for this section, but it is not recommended
+      # for security reasons.
+      host="&operHost;"
+
       nopassword="yes"
       sslonly="&operSSLOnly;"
       type="NetAdmin">


### PR DESCRIPTION
Without setting `host` it seems to be impossible to log-in to the certificate-based oper block.

<!--

Thanks for the contribution!

We provide a little checklist for Pull Requests to make sure everything is fine.

If you are working on a pull request please add WIP to its title. We will still
  look at it and discuss if needed.
-->

## Checklist

- [x] Implementation
- [x] Tests
- [x] Docs

<!--

Some details for the checklist:

Implementation means the complete implementation of your feature.

Tests means adding a shell script in `tests/` to check that your implementation
  works correctly. This makes sure no other pull request breaks a feature. We
  would really welcome it, because simplifies our life.

Docs means additions to the README.md in case you add something which needs
  user interaction or knowledge.

Feel free to place more detail below or on top of your pull request :)

We try to create a great user experience for this image. Every contribution is
  welcome and we help you as good as we can.
-->
